### PR TITLE
dont try to install already installed packages.

### DIFF
--- a/rakelib/homebrew.rake
+++ b/rakelib/homebrew.rake
@@ -33,7 +33,8 @@ namespace :homebrew do
       end
     end
     
-    package_list.each do |p|
+    installables = package_list - `brew list`.split(/\s/)
+    installables.each do |p|
       sh "brew install #{p}" do |ok, res|
         #do nothing, don't die when brew throws an error if already installed
       end


### PR DESCRIPTION
I came across your scripts when trying to setup something similar for myself. I added this tweak to skip packages that are already installed. This eliminates those errors and makes it easier to find actionable errors when you run the script (like things you have to link).

The downside is that it won't upgrade out of date packages. You could get around that by adding back in the intersection of package_list and `brew outdated` but I chose not to do that for my needs.

You might not need or want this at all, but since your scripts were helpful to me, I thought I'd at least suggest it. Thanks!
